### PR TITLE
Fix whitespace handling when normalising champion names

### DIFF
--- a/pbai/data/dataset.py
+++ b/pbai/data/dataset.py
@@ -140,8 +140,11 @@ class DraftDataset(Dataset):
         if pd.isna(champion_name) or champion_name == 'nan':
             champion_name = "MISSING"
         
-        # Convert to uppercase for consistency
-        champion_name = str(champion_name).upper()
+        # Normalize spacing/casing because Oracle's Elixir exports often include
+        # padding around champion names. Whitespace would otherwise cause a
+        # lookup miss and mark the champion as ``MISSING`` which discards the
+        # sample entirely (and tanks model accuracy).
+        champion_name = str(champion_name).strip().upper()
         
         # Return sequential index
         return self.champion2idx.get(champion_name, self.champion2idx['MISSING'])

--- a/tests/test_draft_dataset.py
+++ b/tests/test_draft_dataset.py
@@ -133,6 +133,23 @@ class DraftDatasetPreprocessSamplesTest(unittest.TestCase):
             dataset._normalize_champion_id('FIDDLESTICKS'),
         )
 
+    def test_whitespace_in_source_names_does_not_drop_samples(self):
+        """Champions with padded whitespace should still be recognised."""
+
+        messy_dataframe = self.dataframe.copy()
+        messy_dataframe.loc[0, 'ban1'] = ' Aatrox '
+        messy_dataframe.loc[1, 'ban1'] = '  Darius'
+
+        dataset = DraftDataset(FakeIngestionService(messy_dataframe))
+
+        first_sample = dataset.samples[0]
+        expected_index = dataset._normalize_champion_id('AATROX')
+        self.assertEqual(first_sample['target'], expected_index)
+
+        # The follow-up event should carry the trimmed ban forward as context.
+        second_sample = dataset.samples[1]
+        self.assertEqual(second_sample['draft_sequence'][0], expected_index)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- strip extraneous whitespace before normalising champion names so Oracle's Elixir rows map to the correct indices instead of being dropped
- add a regression test covering padded champion names to ensure samples keep the trimmed bans/picks in the draft sequence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d84c259e1483249266ede2d92902a9