### PR TITLE
Document pipeline stages and add ingestion helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # pb-ai: League of Legends Pick/Ban Outcome Predictor
 
 ## Project Vision
-This project is part of a larger system to predict the likely outcome of a professional League of Legends pick and ban phase, using machine learning and historical data. The full system will include:
+This project is part of a larger system to predict the likely outcome of a professional League of Legends pick and ban phase using
+machine learning and historical data. The full system will include:
 - Automated data ingestion (cronjob)
 - Reliable storage for raw and processed data
 - Model training and evaluation
@@ -12,45 +13,89 @@ This project is part of a larger system to predict the likely outcome of a profe
 ```
 pb-ai/
   pbai/
-    __init__.py
     data/
-      __init__.py
+      data_ingestion_service.py
       dataset.py
-      loader.py
+      processors/
+      storage/
     models/
-      __init__.py
       mlp.py
     training/
-      __init__.py
-      train.py
+      train_oracle_elixir.py
     utils/
-      __init__.py
       champ_enum.py
       config.py
   scripts/
-    train.py
+    ingest_oracle_elixir.py
+    run_pipeline.py
+    train_oracle_elixir.py
     infer.py
   resources/
+    2025_LoL_esports_match_data_from_OraclesElixir.csv
     champions.json
-    fp-data.csv
-    fp-data2.csv
   requirements.txt
   README.md
 ```
 
 ## Setup
 1. Clone the repository and navigate to the project root.
-2. Install dependencies:
+2. (Optional) Create and activate a virtual environment.
+3. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-3. Ensure data files are in the `resources/` directory.
+4. Ensure the Oracle's Elixir CSV is available in `resources/` (or supply a custom path when running the scripts).
 
-## Training the Model
-Run the training script:
+## Workflow Overview
+| Stage | Description | Command |
+|-------|-------------|---------|
+| Data ingestion | Cache the Oracle's Elixir CSV into parquet slices (`data/processed`) for teams and players. | `python scripts/ingest_oracle_elixir.py` |
+| Model training | Build the `DraftDataset` and train the `DraftMLP` model, logging metrics along the way. | `python scripts/train_oracle_elixir.py` |
+| Inference (placeholder) | Reserved for future model loading and prediction logic. | `python scripts/infer.py` |
+| End-to-end pipeline | Run ingestion and training back-to-back with a single command. | `python scripts/run_pipeline.py` |
+
+Each stage can be run independently as you iterate on the pipeline, or chained via the end-to-end script for a complete refresh.
+
+### Stage 1 – Data Ingestion
+The ingestion step materializes the CSV export from Oracle's Elixir into versioned parquet files so downstream stages can operate on
+fast local reads. Under the hood the script relies on `DataIngestionService` and `FileRepository` to manage caching and filtering.
+
 ```bash
-python scripts/train.py
+python scripts/ingest_oracle_elixir.py \
+  --source-path resources/2025_LoL_esports_match_data_from_OraclesElixir.csv \
+  --processed-dir data/processed
 ```
+
+- Use `--force-refresh` to ignore cached parquet files and re-read the CSV.
+- Data is written to `data/processed/` with rolling version cleanup to keep disk usage in check.
+
+### Stage 2 – Model Training
+Training consumes the cached data, constructs the `DraftDataset`, and optimizes a multilayer perceptron that predicts the next pick or ban.
+Loss curves, validation accuracy, and basic sample predictions are printed to aid debugging.
+
+```bash
+python scripts/train_oracle_elixir.py \
+  --oracle-elixir-path resources/2025_LoL_esports_match_data_from_OraclesElixir.csv \
+  --processed-data-dir data/processed \
+  --model-path models/draft_mlp_oracle_elixir.pth
+```
+
+Adjust `--epochs`, `--batch-size`, or `--learning-rate` to experiment with training dynamics. The best validation checkpoint is saved to the path
+supplied via `--model-path` and evaluation metrics are reported against a held-out test split.
+
+### Stage 3 – Inference (coming soon)
+The inference CLI stub exists so that future work can plug in trained model weights and champion draft scenarios without reshaping the
+project layout. Once implemented it will reuse the cached data schemas and `DraftMLP` definition.
+
+### One-Command Pipeline
+To start from raw CSV and finish with a trained checkpoint in one step, use the pipeline script:
+
+```bash
+python scripts/run_pipeline.py
+```
+
+The script runs ingestion (unless `--skip-ingestion` is provided) and then launches the same training routine as Stage 2. All CLI flags exposed
+by the individual stages are available here as well, making it convenient to automate cron-style refreshes or rapid experiments.
 
 ## Future Components
 - **Data Ingestion:** Automated scripts to fetch and preprocess new data daily.

--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -1,7 +1,7 @@
-"""
-infer.py
+"""Entry point for running inference with trained models.
 
-This script will serve as the entry point for running inference with trained models in the future.
+This placeholder keeps the CLI contract in place while the inference
+pipeline is being implemented.
 """
 
-# Future: Implement model loading and inference logic here. 
+# TODO: Implement model loading and inference logic here.

--- a/scripts/ingest_oracle_elixir.py
+++ b/scripts/ingest_oracle_elixir.py
@@ -1,0 +1,137 @@
+"""CLI helper for materializing Oracle's Elixir data locally.
+
+The training pipeline expects cleaned Oracle's Elixir data to be cached in
+``data/processed``.  This script delegates to :class:`pbai.data` services to
+read the CSV export, store a versioned copy, and create convenience slices
+for teams and players.  Running it regularly keeps the cache synchronized
+with the raw CSV that ships in ``resources`` (or a custom path supplied via
+``--source-path``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+
+
+# Ensure project root is importable when the script is invoked directly.
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from pbai.data.data_ingestion_service import DataIngestionService
+from pbai.data.storage import FileRepository
+
+
+def ingest_oracle_elixir(
+    source_path: str,
+    processed_dir: str = "data/processed",
+    force_refresh: bool = False,
+) -> dict:
+    """Materialize Oracle's Elixir data and return a short summary.
+
+    Args:
+        source_path: Path to the Oracle's Elixir CSV export.
+        processed_dir: Directory where parquet caches should live.
+        force_refresh: Whether to ignore cached parquet files and reload
+            the CSV even if it has not changed.
+
+    Returns:
+        Dictionary containing counts for the datasets that were cached.
+    """
+
+    if not os.path.exists(source_path):
+        raise FileNotFoundError(
+            f"Oracle's Elixir CSV not found at '{source_path}'. "
+            "Pass --source-path to point to the file."
+        )
+
+    logging.info("Loading Oracle's Elixir export from %s", source_path)
+    repository = FileRepository(processed_dir)
+    service = DataIngestionService(repository, source_path)
+
+    # ``get_all_data_df`` performs the heavy lifting of saving a versioned copy
+    # to disk whenever the CSV is newer than the cached parquet.
+    all_df = service.get_all_data_df(force_refresh=force_refresh)
+    logging.info("Loaded %d rows of raw match data", len(all_df))
+
+    # Player and team slices are cached explicitly here so downstream stages can
+    # reuse them without repeating the filtering work.
+    players_df = service.get_players_df()
+    teams_df = service.get_teams_df()
+
+    version = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    repository.save_raw_player_data(players_df, version)
+    repository.save_raw_team_data(teams_df, version)
+    repository.cleanup_old_versions()
+
+    summary = {
+        "all_rows": len(all_df),
+        "player_rows": len(players_df),
+        "team_rows": len(teams_df),
+        "processed_dir": processed_dir,
+    }
+    logging.info(
+        "Oracle's Elixir data cached (all=%(all_rows)d, players=%(player_rows)d, "
+        "teams=%(team_rows)d) in %(processed_dir)s",
+        summary,
+    )
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Cache Oracle's Elixir match data for downstream stages."
+    )
+    parser.add_argument(
+        "--source-path",
+        default=os.path.join(
+            PROJECT_ROOT,
+            "resources",
+            "2025_LoL_esports_match_data_from_OraclesElixir.csv",
+        ),
+        help="Path to the Oracle's Elixir CSV export.",
+    )
+    parser.add_argument(
+        "--processed-dir",
+        default=os.path.join(PROJECT_ROOT, "data", "processed"),
+        help="Directory where parquet caches will be written.",
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Ignore cached parquet files and reload the CSV from disk.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="Verbosity for log messages.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+    summary = ingest_oracle_elixir(
+        source_path=args.source_path,
+        processed_dir=args.processed_dir,
+        force_refresh=args.force_refresh,
+    )
+
+    print("Oracle's Elixir data cached:")
+    for key, value in summary.items():
+        print(f"  {key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,0 +1,112 @@
+"""Run the full data-to-model pipeline in a single command."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Ensure project root and scripts directory are importable when running directly.
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS_DIR = os.path.join(PROJECT_ROOT, "scripts")
+for path in {PROJECT_ROOT, SCRIPTS_DIR}:
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+from ingest_oracle_elixir import ingest_oracle_elixir
+from pbai.training.train_oracle_elixir import train_oracle_elixir
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Execute ingestion and model training back-to-back."
+    )
+    parser.add_argument(
+        "--source-path",
+        default=os.path.join(
+            PROJECT_ROOT,
+            "resources",
+            "2025_LoL_esports_match_data_from_OraclesElixir.csv",
+        ),
+        help="Path to the Oracle's Elixir CSV export.",
+    )
+    parser.add_argument(
+        "--processed-dir",
+        default=os.path.join(PROJECT_ROOT, "data", "processed"),
+        help="Directory where parquet caches will be written.",
+    )
+    parser.add_argument(
+        "--model-path",
+        default=os.path.join(
+            PROJECT_ROOT, "models", "draft_mlp_oracle_elixir.pth"
+        ),
+        help="Destination path for the trained model weights.",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=20,
+        help="Number of training epochs to run.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Mini-batch size used during training.",
+    )
+    parser.add_argument(
+        "--learning-rate",
+        type=float,
+        default=0.001,
+        help="Learning rate for the optimizer.",
+    )
+    parser.add_argument(
+        "--skip-ingestion",
+        action="store_true",
+        help="Assume data is already cached and skip the ingestion stage.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="Verbosity for log messages.",
+    )
+    return parser.parse_args(argv)
+
+
+def run_pipeline(args: argparse.Namespace) -> None:
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+    if args.skip_ingestion:
+        logging.info("Skipping ingestion stage (per --skip-ingestion)")
+    else:
+        ingest_summary = ingest_oracle_elixir(
+            source_path=args.source_path,
+            processed_dir=args.processed_dir,
+            force_refresh=False,
+        )
+        logging.info("Ingestion summary: %s", ingest_summary)
+
+    logging.info("Starting training stage")
+    train_oracle_elixir(
+        oracle_elixir_path=args.source_path,
+        processed_data_dir=args.processed_dir,
+        model_path=args.model_path,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.learning_rate,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    run_pipeline(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document the data, training, and pipeline stages in the README with accurate commands
- add a CLI helper for caching Oracle's Elixir data and an end-to-end pipeline runner
- update the inference stub to keep the future CLI entry point in place

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d862d4b89c8324a54d4c4a56848b34