### PR TITLE
Add CSV export controls to ingestion and training workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ python scripts/ingest_oracle_elixir.py \
 
 - Use `--force-refresh` to ignore cached parquet files and re-read the CSV.
 - Data is written to `data/processed/` with rolling version cleanup to keep disk usage in check.
+- Pass `--export-format csv` to emit human-readable CSV siblings next to the parquet caches.
 
 ### Stage 2 – Model Training
 Training consumes the cached data, constructs the `DraftDataset`, and optimizes a multilayer perceptron that predicts the next pick or ban.
@@ -82,6 +83,7 @@ python scripts/train_oracle_elixir.py \
 
 Adjust `--epochs`, `--batch-size`, or `--learning-rate` to experiment with training dynamics. The best validation checkpoint is saved to the path
 supplied via `--model-path` and evaluation metrics are reported against a held-out test split.
+- Use `--dataset-export-dir <path>` (optionally paired with `--dataset-export-format csv`) to snapshot the latest aggregation tables for inspection.
 
 ### Stage 3 – Inference (coming soon)
 The inference CLI stub exists so that future work can plug in trained model weights and champion draft scenarios without reshaping the
@@ -95,7 +97,8 @@ python scripts/run_pipeline.py
 ```
 
 The script runs ingestion (unless `--skip-ingestion` is provided) and then launches the same training routine as Stage 2. All CLI flags exposed
-by the individual stages are available here as well, making it convenient to automate cron-style refreshes or rapid experiments.
+by the individual stages—including `--ingest-export-format` and `--dataset-export-dir`—are available here as well, making it convenient to
+automate cron-style refreshes or rapid experiments.
 
 ## Future Components
 - **Data Ingestion:** Automated scripts to fetch and preprocess new data daily.

--- a/pbai/data/data_ingestion_service.py
+++ b/pbai/data/data_ingestion_service.py
@@ -4,15 +4,43 @@ Data service layer for raw data ingestion and cleaning from Oracle's Elixir data
 
 import os
 import pandas as pd
-from typing import Optional, Dict
+from typing import Optional, Dict, Sequence, List
 from .storage import DataRepository
 
 class DataIngestionService:
     """Service layer for raw data ingestion and cleaning"""
     
-    def __init__(self, repository: DataRepository, source_path: str):
+    def __init__(
+        self,
+        repository: DataRepository,
+        source_path: str,
+        export_formats: Optional[Sequence[str]] = None,
+    ):
         self.repository = repository
         self.source_path = source_path
+        self._export_formats = self._normalize_export_formats(export_formats)
+
+    @staticmethod
+    def _normalize_export_formats(
+        export_formats: Optional[Sequence[str]]
+    ) -> Optional[Sequence[str]]:
+        if export_formats is None:
+            return None
+        if isinstance(export_formats, str):
+            return [export_formats.lower()]
+        normalized: List[str] = []
+        for fmt in export_formats:
+            if fmt is None:
+                continue
+            normalized.append(str(fmt).lower())
+        return normalized or None
+
+    def _resolve_export_formats(
+        self, export_formats: Optional[Sequence[str]]
+    ) -> Optional[Sequence[str]]:
+        if export_formats is not None:
+            return self._normalize_export_formats(export_formats)
+        return self._export_formats
     
     def _ensure_dataframe(self, result, context: str = "") -> pd.DataFrame:
         if isinstance(result, pd.DataFrame):
@@ -22,14 +50,23 @@ class DataIngestionService:
         else:
             raise TypeError(f"Expected DataFrame or Series from {context}")
 
-    def get_all_data_df(self, force_refresh: bool = False) -> pd.DataFrame:
+    def get_all_data_df(
+        self,
+        force_refresh: bool = False,
+        export_formats: Optional[Sequence[str]] = None,
+    ) -> pd.DataFrame:
         """Get cleaned all_data DataFrame, refreshing if needed"""
         source_modified = os.path.getmtime(self.source_path)
+        effective_export_formats = self._resolve_export_formats(export_formats)
         if force_refresh or self.repository.is_data_stale("all", source_modified):
             # Read and clean raw data
             source_data = pd.read_csv(self.source_path)
             # Optionally: add basic cleaning/validation here
-            self.repository.save_all_raw_data(source_data, pd.Timestamp.now().strftime("%Y%m%d_%H%M%S"))
+            self.repository.save_all_raw_data(
+                source_data,
+                pd.Timestamp.now().strftime("%Y%m%d_%H%M%S"),
+                export_formats=effective_export_formats,
+            )
             return source_data
         else:
             result = self.repository.load_all_raw_data()

--- a/pbai/data/storage/repository.py
+++ b/pbai/data/storage/repository.py
@@ -3,7 +3,7 @@ Abstract repository interface for data persistence.
 """
 
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Sequence
 import pandas as pd
 
 
@@ -11,7 +11,12 @@ class DataRepository(ABC):
     """Abstract interface for data persistence"""
     
     @abstractmethod
-    def save_all_raw_data(self, games: pd.DataFrame, version: str) -> None:
+    def save_all_raw_data(
+        self,
+        games: pd.DataFrame,
+        version: str,
+        export_formats: Optional[Sequence[str]] = None,
+    ) -> None:
         """Save processed game data with version tracking"""
         pass
     
@@ -21,7 +26,11 @@ class DataRepository(ABC):
         pass
     
     @abstractmethod
-    def save_raw_series_data(self, series: pd.DataFrame) -> None:
+    def save_raw_series_data(
+        self,
+        series: pd.DataFrame,
+        export_formats: Optional[Sequence[str]] = None,
+    ) -> None:
         """Save series grouping and fearless detection results"""
         pass
     
@@ -31,7 +40,12 @@ class DataRepository(ABC):
         pass
     
     @abstractmethod
-    def save_raw_player_data(self, players: pd.DataFrame, version: str) -> None:
+    def save_raw_player_data(
+        self,
+        players: pd.DataFrame,
+        version: str,
+        export_formats: Optional[Sequence[str]] = None,
+    ) -> None:
         """Save player data (participantid 1-10)"""
         pass
     
@@ -41,7 +55,12 @@ class DataRepository(ABC):
         pass
 
     @abstractmethod
-    def save_raw_team_data(self, teams: pd.DataFrame, version: str) -> None:
+    def save_raw_team_data(
+        self,
+        teams: pd.DataFrame,
+        version: str,
+        export_formats: Optional[Sequence[str]] = None,
+    ) -> None:
         """Save team data (participantid 100, 200)"""
         pass
     

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -67,6 +67,30 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Assume data is already cached and skip the ingestion stage.",
     )
     parser.add_argument(
+        "--ingest-export-format",
+        dest="ingest_export_formats",
+        action="append",
+        choices=["csv"],
+        help=(
+            "Additional formats (beyond parquet) to export during ingestion. "
+            "Repeat to request multiple formats."
+        ),
+    )
+    parser.add_argument(
+        "--dataset-export-dir",
+        help="Optional directory where DraftDataset will emit intermediate CSV snapshots.",
+    )
+    parser.add_argument(
+        "--dataset-export-format",
+        dest="dataset_export_formats",
+        action="append",
+        choices=["csv"],
+        help=(
+            "Additional formats for DraftDataset intermediate exports. "
+            "Repeat to request multiple formats."
+        ),
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
@@ -88,6 +112,7 @@ def run_pipeline(args: argparse.Namespace) -> None:
             source_path=args.source_path,
             processed_dir=args.processed_dir,
             force_refresh=False,
+            export_formats=args.ingest_export_formats,
         )
         logging.info("Ingestion summary: %s", ingest_summary)
 
@@ -99,6 +124,8 @@ def run_pipeline(args: argparse.Namespace) -> None:
         epochs=args.epochs,
         batch_size=args.batch_size,
         lr=args.learning_rate,
+        dataset_export_dir=args.dataset_export_dir,
+        dataset_export_formats=args.dataset_export_formats,
     )
 
 

--- a/scripts/train_oracle_elixir.py
+++ b/scripts/train_oracle_elixir.py
@@ -1,10 +1,114 @@
-"""
-CLI entry point for training the Oracle's Elixir draft model.
-"""
-import sys
+"""CLI entry point for training the Oracle's Elixir draft model."""
+
+from __future__ import annotations
+
+import argparse
+import logging
 import os
+import sys
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from pbai.training.train_oracle_elixir import train_oracle_elixir
 
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train the Oracle's Elixir draft model using cached data.",
+    )
+    parser.add_argument(
+        "--oracle-elixir-path",
+        default=os.path.join(
+            PROJECT_ROOT,
+            "resources",
+            "2025_LoL_esports_match_data_from_OraclesElixir.csv",
+        ),
+        help="Path to the Oracle's Elixir CSV export.",
+    )
+    parser.add_argument(
+        "--processed-data-dir",
+        default=os.path.join(PROJECT_ROOT, "data", "processed"),
+        help="Directory containing cached parquet data.",
+    )
+    parser.add_argument(
+        "--model-path",
+        default=os.path.join(
+            PROJECT_ROOT,
+            "models",
+            "draft_mlp_oracle_elixir.pth",
+        ),
+        help="Destination path for the trained model checkpoint.",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=20,
+        help="Number of training epochs.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Mini-batch size for the data loader.",
+    )
+    parser.add_argument(
+        "--learning-rate",
+        type=float,
+        default=0.001,
+        help="Learning rate for the optimizer.",
+    )
+    parser.add_argument(
+        "--ingestion-export-format",
+        dest="ingestion_export_formats",
+        action="append",
+        choices=["csv"],
+        help=(
+            "Additional formats (besides parquet) to materialize when refreshing cached data."
+        ),
+    )
+    parser.add_argument(
+        "--dataset-export-dir",
+        help="Optional directory where DraftDataset will export intermediate CSV snapshots.",
+    )
+    parser.add_argument(
+        "--dataset-export-format",
+        dest="dataset_export_formats",
+        action="append",
+        choices=["csv"],
+        help="Additional formats for DraftDataset intermediate exports.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="Verbosity for log messages.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+    train_oracle_elixir(
+        oracle_elixir_path=args.oracle_elixir_path,
+        processed_data_dir=args.processed_data_dir,
+        model_path=args.model_path,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.learning_rate,
+        ingestion_export_formats=args.ingestion_export_formats,
+        dataset_export_dir=args.dataset_export_dir,
+        dataset_export_formats=args.dataset_export_formats,
+    )
+    return 0
+
+
 if __name__ == "__main__":
-    train_oracle_elixir()
+    raise SystemExit(main())

--- a/tests/test_draft_dataset.py
+++ b/tests/test_draft_dataset.py
@@ -1,4 +1,5 @@
 import unittest
+
 import pandas as pd
 
 from pbai.data.dataset import DraftDataset
@@ -8,7 +9,7 @@ class FakeIngestionService:
     def __init__(self, dataframe: pd.DataFrame):
         self._df = dataframe
 
-    def get_all_data_df(self, force_refresh: bool = False) -> pd.DataFrame:
+    def get_all_data_df(self, force_refresh: bool = False, export_formats=None) -> pd.DataFrame:
         return self._df.copy()
 
 


### PR DESCRIPTION
## Summary
- allow repository and ingestion layers to emit CSV artifacts alongside existing parquet outputs
- add DraftDataset export hooks and surface new flags in ingestion/training CLIs and documentation
- cover the new export pathways with updated dataset aggregation tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8873e2d0c8324aa214d0fa7e0d24e