### PR TITLE
Refactor champion name sanitization

### DIFF
--- a/pbai/utils/champion_sanitizer.py
+++ b/pbai/utils/champion_sanitizer.py
@@ -1,0 +1,33 @@
+"""Utilities for normalising champion names across different data sources."""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Optional
+
+
+class ChampionSanitizer:
+    """Apply consistent transformations to champion names used throughout the app."""
+
+    def sanitize(self, champion_name: Optional[str]) -> str:
+        """Return a normalised champion name suitable for dictionary lookups."""
+
+        if champion_name is None:
+            return ""
+
+        cleaned = str(champion_name).strip()
+        if not cleaned:
+            return ""
+
+        cleaned = cleaned.upper()
+        cleaned = "".join(ch for ch in cleaned if not self._is_punctuation(ch))
+        # Collapse repeated whitespace that can arise from punctuation removal.
+        cleaned = " ".join(cleaned.split())
+        return cleaned
+
+    @staticmethod
+    def _is_punctuation(character: str) -> bool:
+        """Return True when the character is classified as punctuation in Unicode."""
+
+        return unicodedata.category(character).startswith("P")
+


### PR DESCRIPTION
## Summary
- add a dedicated `ChampionSanitizer` helper that uppercases names and strips punctuation
- use the sanitizer throughout the draft dataset to normalise champion lookups and fearless history
- extend draft dataset tests to cover punctuation handling and updated fearless expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8a676962c83248f0474e14832f086