### PR TITLE
Sanitize idx2champion mapping

### DIFF
--- a/pbai/data/dataset.py
+++ b/pbai/data/dataset.py
@@ -39,13 +39,13 @@ class DraftDataset(Dataset):
         # Add MISSING as index 0 (valid input, never valid output)
         self.missing_key = self.champion_sanitizer.sanitize('MISSING')
         self.champion2idx[self.missing_key] = 0
-        self.idx2champion[0] = 'MISSING'
+        self.idx2champion[0] = self.missing_key
         # Map real champions to indices 1-170 (excluding 'MISSING')
         real_champions = [name for name, member in self.champ_enum.__members__.items() if name != 'MISSING']
         for i, champ_name in enumerate(real_champions, start=1):
             sanitized_name = self.champion_sanitizer.sanitize(champ_name)
             self.champion2idx[sanitized_name] = i
-            self.idx2champion[i] = champ_name
+            self.idx2champion[i] = sanitized_name
         self.num_champions = len(self.champion2idx)
         # TODO: If you want the model to learn series-level strategy (across all games in a series),
         #       increase draft_features (e.g., to 100) and provide the full series draft history as input.

--- a/tests/test_draft_dataset.py
+++ b/tests/test_draft_dataset.py
@@ -173,6 +173,15 @@ class DraftDatasetPreprocessSamplesTest(unittest.TestCase):
         normalized_index = dataset._normalize_champion_id("KAI'SA") - 1
         self.assertEqual(mask[normalized_index], 0)
 
+    def test_idx2champion_uses_sanitized_names(self):
+        dataset = DraftDataset(FakeIngestionService(self.dataframe))
+
+        normalized_index = dataset._normalize_champion_id("KAI'SA")
+        self.assertEqual(
+            dataset.idx2champion[normalized_index],
+            dataset.champion_sanitizer.sanitize("KAI'SA"),
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- store sanitized champion names in DraftDataset.idx2champion so downstream logging never sees punctuation
- cover the sanitised idx2champion mapping with a unit test

## Testing
- pytest tests/test_draft_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68d8c528ce7483249966408125b4c3a4